### PR TITLE
Handle nil to empty string

### DIFF
--- a/lib/delta_changes.rb
+++ b/lib/delta_changes.rb
@@ -110,7 +110,7 @@ module DeltaChanges
     end
 
     def delta_changes_field_changed?(attr, old, value)
-      return true if old.nil? && !value.nil?
+      return true if !old.present? && value.present?
       if ActiveRecord::VERSION::STRING < '4.2.0'
         _field_changed?(attr, old, value)
       elsif ActiveRecord::VERSION::MAJOR < 5

--- a/spec/delta_changes_spec.rb
+++ b/spec/delta_changes_spec.rb
@@ -46,6 +46,11 @@ describe DeltaChanges do
       expect(user.delta_changes).to eq({})
     end
 
+    it 'should not be filled if a nil attribute changes to empty string' do
+      user = User.new(:score => '')
+      expect(user.delta_changes).to eq({})
+    end
+
     it 'should be filled by explicit tracked attribute changes' do
       user = User.new(:foo => 1)
       user.foo_delta_will_change!


### PR DESCRIPTION
I was seeing an issue where changing an integer attribute from `nil` to `""` would result in a delta of `{"foo"=>[nil, nil]}`.  This just changes from a `nil` check to a `present` check to account for empty string values.

@grosser 